### PR TITLE
Fixed rarity on Celebi from 'V' to 'Rare Ultra'

### DIFF
--- a/json/cards/Sword & Shield.json
+++ b/json/cards/Sword & Shield.json
@@ -12,7 +12,7 @@
     "convertedRetreatCost": 1,
     "number": "1",
     "artist": "PLANETA Igarashi",
-    "rarity": "V",
+    "rarity": "Rare Ultra",
     "series": "Sword & Shield",
     "set": "Sword & Shield",
     "setCode": "swsh1",


### PR DESCRIPTION
Celebi had a rarity value of 'V' while all other V cards had 'Rare Ultra'. Change Celebi to match others.